### PR TITLE
Defect resolved in passing the json string

### DIFF
--- a/WebUI/MhdWrapper.cpp
+++ b/WebUI/MhdWrapper.cpp
@@ -127,7 +127,7 @@ int ReturnFile(struct MHD_Connection *connection,
 	return ret;
 }
 
-int ReturnJSON(struct MHD_Connection *connection, const char* jsoncstr)
+int ReturnJSON(struct MHD_Connection *connection, const std::string& json_str)
 {
 	struct MHD_Response *response;
 	int ret;
@@ -136,8 +136,8 @@ int ReturnJSON(struct MHD_Connection *connection, const char* jsoncstr)
 	 MHD_RESPMEM_MUST_FREE
 	 MHD_RESPMEM_MUST_COPY
 	 */
-	response = MHD_create_response_from_buffer(strlen(jsoncstr),
-		(void *)jsoncstr,
+	response = MHD_create_response_from_buffer(json_str.size(),
+		(void *)json_str.c_str(),
 		MHD_RESPMEM_MUST_COPY);
 	MHD_add_response_header (response, "Content-Type", MimeTypeMap.at("json").c_str());
 	ret = MHD_queue_response(connection, MHD_HTTP_OK, response);

--- a/WebUI/MhdWrapper.h
+++ b/WebUI/MhdWrapper.h
@@ -84,6 +84,6 @@ void request_completed(void *cls, struct MHD_Connection *connection,
 	void **con_cls,
 	enum MHD_RequestTerminationCode toe);
 int ReturnFile(struct MHD_Connection *connection, const char *url);
-int ReturnJSON(struct MHD_Connection *connection, const char* jsoncstr);
+int ReturnJSON(struct MHD_Connection *connection, const std::string& json_str);
 
 #endif /* defined(__opendatacon__MhdWrapper__) */

--- a/WebUI/WebUI.cpp
+++ b/WebUI/WebUI.cpp
@@ -198,9 +198,7 @@ int WebUI::http_ahc(void *cls,
 		event = Responders[ResponderName]->ExecuteCommand(command, params);
 		pWriter->write(event, &oss); oss<<std::endl;
 
-		const char* jsoncstr = oss.str().c_str();
-
-		return ReturnJSON(connection, jsoncstr);
+		return ReturnJSON(connection, oss.str());
 	}
 	else
 	{


### PR DESCRIPTION
While constructing the json as string '\0' could have creating the problem.
Therefore I have removed the char* passing to the function, now I am sending const std::string which is more reliable and can send the data correctly 