### PR TITLE
Develop md3 cb fixes

### DIFF
--- a/Code/Ports/CBPort/CB.h
+++ b/Code/Ports/CBPort/CB.h
@@ -140,6 +140,10 @@ public:
 		std::shared_lock<std::shared_timed_mutex> lck(m);
 		return val;
 	}
+	bool getandclear(void)
+	{
+		return getandset(false);
+	}
 private:
 	mutable std::shared_timed_mutex m;
 	bool val;
@@ -167,6 +171,14 @@ public:
 	std::string to_string() const
 	{
 		return std::to_string(Packet) + ((Position == PayloadABType::PositionA) ? "A" : (Position == PayloadABType::PositionB) ? "B" : "Error");
+	}
+	bool Valid()
+	{
+		return Position != PayloadABType::Error;
+	}
+	bool operator==(const PayloadLocationType& src)
+	{
+		return (Position == src.Position) && (Packet == src.Packet);
 	}
 };
 
@@ -317,7 +329,7 @@ public:
 
 protected:
 	// Only the values below will be changed in two places
-	uint8_t Binary = 0x01;
+	uint8_t Binary = 0x01;		// NOTE: WHY WOULD I DEFAULT THESE TO 1???
 	bool Changed = true;
 	bool MomentaryChangeStatus = false; // Used only for MCA, MCB and MCC types. Not valid for other types.
 	BinaryPointType PointType = DIG;

--- a/Code/Ports/CBPort/CBMasterPort.cpp
+++ b/Code/Ports/CBPort/CBMasterPort.cpp
@@ -605,16 +605,11 @@ void CBMasterPort::ProccessScanPayload(uint16_t data, uint8_t group, PayloadLoca
 				}
 			});
 	}
-	if (!FoundMatch)
+	if (MyPointConf->PointTable.IsStatusByteLocation(group, payloadlocation))
 	{
-		// See if it is a StatusByte we need to handle - there is only one status byte, but it could be requested in several groups. So deal with it whenever it comes back
-		MyPointConf->PointTable.ForEachMatchingStatusByte(group, payloadlocation, [this, group, payloadlocation, &FoundMatch](void)
-			{
-				// We have a matching status byte, set a flag to indicate we have a match.
-				LOGDEBUG("{} Received a Status Byte at : {} - {}", Name, group, payloadlocation.to_string());
-				//TODO: Not sure what we are going to do with the status byte - YET
-				FoundMatch = true;
-			});
+		FoundMatch = true;
+		// TODO: The SOE data available bit being set can/should trigger a SOE scan of the outstation. SOE Buffer overflow hmm. Power cycle to trigger a complete rescan.
+		LOGDEBUG("{} Received a Status Payload, any defined Digitals will be processed. SOE flags and Power On ignored: {} ", Name, payloadlocation.to_string());
 	}
 	if (!FoundMatch)
 	{

--- a/Code/Ports/CBPort/CBOutstationPort.cpp
+++ b/Code/Ports/CBPort/CBOutstationPort.cpp
@@ -51,9 +51,8 @@ CBOutstationPort::CBOutstationPort(const std::string & aName, const std::string 
 	std::string over = "None";
 	if (aConfOverrides.isObject()) over = aConfOverrides.toStyledString();
 
-	//TODO: Do we need these flags for Conitel/Baker
-	SystemFlags.SetDigitalChangedFlagCalculationMethod(std::bind(&CBOutstationPort::DigitalChangedFlagCalculationMethod, this));
-	SystemFlags.SetTimeTaggedDataAvailableFlagCalculationMethod(std::bind(&CBOutstationPort::TimeTaggedDataAvailableFlagCalculationMethod, this));
+	SystemFlags.SetSOEAvailableFn(std::bind(&CBOutstationPort::SOEAvailableFn, this));
+	SystemFlags.SetSOEOverflowFn(std::bind(&CBOutstationPort::SOEOverflowFn, this));
 
 	IsOutStation = true;
 

--- a/Code/Ports/CBPort/CBPointConf.cpp
+++ b/Code/Ports/CBPort/CBPointConf.cpp
@@ -457,20 +457,12 @@ void CBPointConf::ProcessStatusByte(const Json::Value& JSONNode)
 			error = true;
 		}
 
-		if (JSONNode[n].isMember("Channel"))
-			channel = JSONNode[n]["Channel"].asUInt();
-		else
-		{
-			LOGERROR(" A point needs a \"Channel\" : " + JSONNode[n].toStyledString());
-			error = true;
-		}
-
 		if (!error)
 		{
-			if (PointTable.AddStatusByteToCBMap(numeric_cast<uint8_t>(group), numeric_cast<uint8_t>(channel), payloadlocation))
+			if (PointTable.AddStatusByteToCBMap(numeric_cast<uint8_t>(group), payloadlocation))
 			{
-				// The poll group now only has a group number. We need a Group structure to have links to all the points so we can collect them easily.
-				LOGDEBUG("Adding a Status Byte - Group: " + std::to_string(group) + " Channel: " + std::to_string(channel) + " Payload Location: " + payloadlocation.to_string());
+				// Can only exist in on group, save the group and payload location
+				LOGDEBUG("Adding a Status Byte - Group: " + std::to_string(group) + " Payload Location: " + payloadlocation.to_string());
 			}
 		}
 	}

--- a/Code/Ports/CBPort/CBPointTableAccess.cpp
+++ b/Code/Ports/CBPort/CBPointTableAccess.cpp
@@ -173,17 +173,13 @@ bool CBPointTableAccess::AddBinaryPointToPointTable(const size_t &index, const u
 	return true;
 }
 
-bool CBPointTableAccess::AddStatusByteToCBMap(const uint8_t & group, const uint8_t & channel, const PayloadLocationType & payloadlocation)
+bool CBPointTableAccess::AddStatusByteToCBMap(const uint8_t & group, const PayloadLocationType & payloadlocation)
 {
-	uint16_t CBIndex = GetCBPointMapIndex(group, channel, payloadlocation);
-	if (StatusByteMap.find(CBIndex) != StatusByteMap.end())
-	{
-		LOGERROR("{} Error Duplicate Status Byte CB Index {} - {} - {}",Name,group,channel, payloadlocation.to_string());
-		return false;
-	}
+	// This will only be called once. 
+	StatusBytePayloadLocation = payloadlocation;
+	StatusByteGroup = group;
 
 	UpdateMaxPayload(group, payloadlocation);
-	StatusByteMap[CBIndex] = 0; // Creates the map entry
 	return true;
 }
 
@@ -526,6 +522,19 @@ bool CBPointTableAccess::SetAnalogControlValueUsingODCIndex(const size_t index, 
 	return false;
 }
 
+PayloadLocationType CBPointTableAccess::GetPayLoadLocationFromCBPointMapIndex(const uint16_t& CBIndex)
+{
+	// Top 4 bits group (0-15), Next 4 bits channel (1-12), next 4 bits payload packet number (0-15), next 4 bits 0(A) or 1(B)
+	PayloadLocationType payloadlocation;
+	payloadlocation.Packet = CBIndex >> 4 + 1;
+	payloadlocation.Position = (CBIndex & 0x01) == 0 ? PayloadABType::PositionA : PayloadABType::PositionB;
+	return payloadlocation;
+}
+uint8_t CBPointTableAccess::GetGroupFromCBPointMapIndex(const uint16_t& CBIndex)
+{
+	// Top 4 bits group (0-15), Next 4 bits channel (1-12), next 4 bits payload packet number (0-15), next 4 bits 0(A) or 1(B)
+	return (CBIndex >> 12);
+}
 uint16_t CBPointTableAccess::GetCBPointMapIndex(const uint8_t & group, const uint8_t & channel, const PayloadLocationType & payloadlocation)
 {
 	assert(group <= 0x0F);
@@ -587,15 +596,6 @@ void CBPointTableAccess::ForEachMatchingCounterPoint(const uint8_t & group, cons
 	{
 		// We have a match - call our function with the point as a parameter.
 		fn(*CounterCBPointMap[CBIndex]);
-	}
-}
-void CBPointTableAccess::ForEachMatchingStatusByte(const uint8_t & group, const PayloadLocationType & payloadlocation, const std::function<void(void)>& fn)
-{
-	uint16_t CBIndex = GetCBPointMapIndex(group, 1, payloadlocation); // Use the same index as the points
-	if (StatusByteMap.count(CBIndex) != 0)
-	{
-		// We have a match - call our function
-		fn();
 	}
 }
 

--- a/Code/Ports/CBPort/CBPointTableAccess.h
+++ b/Code/Ports/CBPort/CBPointTableAccess.h
@@ -52,7 +52,7 @@ public:
 	bool AddBinaryPointToPointTable(const size_t & index, const uint8_t & group, const uint8_t & channel, const PayloadLocationType & payloadlocation, const BinaryPointType & pointtype, bool issoe, uint8_t soeindex);
 	bool AddAnalogControlPointToPointTable(const size_t & index, const uint8_t & group, const uint8_t & channel, const AnalogCounterPointType &pointtype);
 
-	bool AddStatusByteToCBMap(const uint8_t & group, const uint8_t & channel, const PayloadLocationType &payloadlocation);
+	bool AddStatusByteToCBMap(const uint8_t & group, const PayloadLocationType &payloadlocation);
 	void UpdateMaxPayload(const uint8_t & group, const PayloadLocationType & payloadlocation);
 
 	bool GetCounterValueUsingODCIndex(const size_t index, uint16_t & res, bool & hasbeenset);
@@ -93,7 +93,10 @@ public:
 	void ForEachMatchingBinaryPoint(const uint8_t & group, const PayloadLocationType & payloadlocation, const std::function<void(CBBinaryPoint&pt)>& fn);
 	void ForEachMatchingAnalogPoint(const uint8_t & group, const PayloadLocationType & payloadlocation, const std::function<void(CBAnalogCounterPoint&pt)>& fn);
 	void ForEachMatchingCounterPoint(const uint8_t & group, const PayloadLocationType & payloadlocation, const std::function<void(CBAnalogCounterPoint&pt)>& fn);
-	void ForEachMatchingStatusByte(const uint8_t & group, const PayloadLocationType & payloadlocation, const std::function<void(void)>& fn);
+	bool IsStatusByteLocation(const uint8_t& group, const PayloadLocationType& payloadlocation)
+	{
+		return ((group == StatusByteGroup) && (StatusBytePayloadLocation == payloadlocation));
+	}
 
 	bool GetMaxPayload(uint8_t group, uint8_t &blockcount);
 
@@ -101,6 +104,9 @@ public:
 	static uint16_t GetCBPointMapIndex(const uint8_t &group, const uint8_t &channel, const PayloadLocationType &payloadlocation); // Group/Payload/Channel
 	static uint16_t GetCBBitMapIndex(const uint8_t& group, uint8_t bit, const PayloadLocationType& payloadlocation, const BinaryPointType& pointtype);
 	static uint16_t GetCBControlPointMapIndex(const uint8_t & group, const uint8_t & channel);
+	PayloadLocationType GetPayLoadLocationFromCBPointMapIndex(const uint16_t& CBIndex);
+	uint8_t GetGroupFromCBPointMapIndex(const uint16_t& CBIndex);
+
 protected:
 
 	// We access the map using a Module:Channel combination, so that they will always be in order. Makes searching the next item easier.
@@ -123,7 +129,8 @@ protected:
 	std::map<uint16_t, std::shared_ptr<CBAnalogCounterPoint>> AnalogControlCBPointMap; // Group/Payload/Channel, CBPoint
 	std::map<size_t, std::shared_ptr<CBAnalogCounterPoint>> AnalogControlODCPointMap;  // Index OpenDataCon, CBPoint
 
-	std::map<uint16_t, uint8_t> StatusByteMap; // Group/Payload/Channel, second parameter empty.
+	uint8_t StatusByteGroup = -1; // Group/Payload/Channel, second parameter bit value.
+	PayloadLocationType StatusBytePayloadLocation;
 
 	std::map<uint8_t, uint8_t> MaxiumPayloadPerGroupMap; // Group 0 to 15, Max payload - a count of 1 to 16.
 

--- a/Code/Ports/CBPort/CBTest.cpp
+++ b/Code/Ports/CBPort/CBTest.cpp
@@ -130,7 +130,9 @@ const char *conffile1 = R"001(
 					{"Index" : 13, "Group" : 3, "PayloadLocation": "2A", "Channel" : 2, "Type" : "MCB"},
 					{"Index" : 14, "Group" : 3, "PayloadLocation": "2A", "Channel" : 3, "Type" : "MCC" },
 					{"Index" : 81, "Group" : 6, "PayloadLocation": "2A", "Channel" : 2, "Type" : "MCB","SOE" : { "Index" : 82}},
-					{"Index" : 90, "Group" : 6, "PayloadLocation": "2A", "Channel" : 3, "Type" : "MCC","SOE" : { "Index" : 91}} ],
+					{"Index" : 90, "Group" : 6, "PayloadLocation": "2A", "Channel" : 3, "Type" : "MCC","SOE" : { "Index" : 91}},
+					{"Index" : 100, "Group": 3, "PayloadLocation": "5A", "Channel" : 8, "Type" : "DIG"} ],	
+					//Internal Supply Low in RST Word must match Group/Location defined below
 
 	"Analogs" : [	{"Index" : 0, "Group" : 3, "PayloadLocation": "3A","Channel" : 1, "Type":"ANA"},
 					{"Index" : 1, "Group" : 3, "PayloadLocation": "3B","Channel" : 1, "Type":"ANA"},
@@ -146,7 +148,7 @@ const char *conffile1 = R"001(
 	"AnalogControls" : [{"Index": 1,  "Group" : 3, "Channel" : 1, "Type" : "CONTROL"}],
 
 	// Special definition, so we know where to find the Remote Status Data in the scanned group.
-	"RemoteStatus" : [{"Group":3, "Channel" : 1, "PayloadLocation": "5A"}]
+	"RemoteStatus" : [{"Group":3, "PayloadLocation": "5A"}]
 
 })001";
 
@@ -240,13 +242,13 @@ void WriteStartLoggingMessage(const std::string& TestName)
 		cblogger->info(msg);
 	}
 	else
-		std::cout << "Error CBPort Logger not operational";
+		std::cout << msg << std::endl;
 
-/*	if (auto odclogger = odc::spdlog_get("opendatacon"))
-                          odclogger->info(msg);
-            else
-                          std::cout << "Error opendatacon Logger not operational";
-                          */
+	if (auto odclogger = odc::spdlog_get("opendatacon"))
+		odclogger->info(msg);
+	//else
+	//	std::cout << "Error opendatacon Logger not operational";
+                          
 }
 void TestSetup(const std::string& TestName, bool writeconffiles = true)
 {
@@ -867,7 +869,7 @@ TEST_CASE("Station - ScanRequest F0")
 	                            "14080022" // Data 2A and 2B
 	                            "00080006"
 	                            "00080006"
-	                            "000fff89";
+	                            "030fffab";
 
 	while(!done_flag)
 		IOS->poll_one();
@@ -905,6 +907,8 @@ TEST_CASE("Station - ScanRequest F0")
 		SendBinaryEvent(IOS,CBOSPort, ODCIndex, ((ODCIndex % 2) == 0));
 	}
 
+	SendBinaryEvent(IOS, CBOSPort, 100, true);  // RTU Power Supply Low
+
 	// MCA,MCB,MCC Set to starting values
 	SendBinaryEvent(IOS,CBOSPort, 12, true);  //CLOSED // MCA inverted on the wire!!
 	SendBinaryEvent(IOS,CBOSPort, 13, false); //OPEN
@@ -919,7 +923,7 @@ TEST_CASE("Station - ScanRequest F0")
 	                "24080018" // Data 2A and 2B
 	                "400a00b6"
 	                "4028000c"
-	                "800f7d19";
+	                "810f7d07";
 
 	CBMessage_t Msg = BuildCBMessageFromASCIIHexString(DesiredResult);
 	assert(Msg[2].GetA() == 1024);                       // Checking payload values
@@ -948,6 +952,7 @@ TEST_CASE("Station - ScanRequest F0")
 	SendBinaryEvent(IOS,CBOSPort, 13, true);  // CLOSED
 	SendBinaryEvent(IOS,CBOSPort, 14, false); // OPEN // Cause more than one change.
 	SendBinaryEvent(IOS,CBOSPort, 14, true);
+	SendBinaryEvent(IOS, CBOSPort, 100, false);  // RTU Power Supply OK
 
 	Response = "Not Set";
 	output << commandblock.ToBinaryString();
@@ -959,7 +964,7 @@ TEST_CASE("Station - ScanRequest F0")
 	                "5c08001e" // Data 2A and 2B
 	                "400a00b6"
 	                "4028000c"
-	                "800f7d19";
+	                "800f7d19";	// First 12 bits is RST Word
 
 	while(!done_flag)
 		IOS->poll_one();
@@ -1425,7 +1430,7 @@ TEST_CASE("Station - Baker ScanRequest F0")
 	                            "02880010" // Data 2A and 2B
 	                            "00080006"
 	                            "00080006"
-	                            "000fff89";
+	                            "0a0fff9b";
 
 	// No need to delay to process result, all done in the InjectCommand at call time.
 	REQUIRE(Response == DesiredResult);
@@ -1474,7 +1479,7 @@ TEST_CASE("Station - Baker ScanRequest F0")
 	                "0248000a" // Data 2A and 2B
 	                "400a00b6"
 	                "4028000c"
-	                "800f7d19";
+	                "880f7d37";
 	while(!done_flag)
 		IOS->poll_one();
 	done_flag = false;
@@ -1507,7 +1512,7 @@ TEST_CASE("Station - Baker ScanRequest F0")
 	                "03a80016" // Data 2A and 2B
 	                "400a00b6"
 	                "4028000c"
-	                "800f7d19";
+	                "880f7d37";
 	while(!done_flag)
 		IOS->poll_one();
 	done_flag = false;
@@ -1529,7 +1534,7 @@ TEST_CASE("Station - Baker ScanRequest F0")
 	                "0058003a" // Data 2A and 2B - no change bits set, add status bits set to 0 in 2A
 	                "400a00b6"
 	                "4028000c"
-	                "c00f7d0b"; // The SOE buffer overflow bit should be set here...
+	                "c80f7d25"; // The SOE buffer overflow bit should be set here...
 	while(!done_flag)
 		IOS->poll_one();
 	done_flag = false;

--- a/Code/Ports/CBPort/main.cpp
+++ b/Code/Ports/CBPort/main.cpp
@@ -91,11 +91,13 @@ extern "C" int run_tests( int argc, char* argv[] )
 			new_argv = argv+1;
 		}
 	}
-	CommandLineLoggingSetup(log_level);
+	if (log_level != spdlog::level::off)
+		CommandLineLoggingSetup(log_level);
 
 	int res =  Catch::Session().run( new_argc, new_argv );
 	// And release here.
-	CommandLineLoggingCleanup();
+	if (log_level != spdlog::level::off)
+		CommandLineLoggingCleanup();
 	return res;
 
 	#else

--- a/Code/Ports/MD3Port/MD3MasterPort.h
+++ b/Code/Ports/MD3Port/MD3MasterPort.h
@@ -90,6 +90,7 @@ public:
 
 	//*** PUBLIC for unit tests only
 	void DoPoll(uint32_t pollgroup);
+	void ClearMD3CommandQueue();
 
 	void ResetDigitalCommandSequenceNumber();
 	uint8_t GetAndIncrementDigitalCommandSequenceNumber(); // Thread protected
@@ -117,12 +118,12 @@ private:
 
 	void SendNextMasterCommand();
 	void UnprotectedSendNextMasterCommand(bool timeoutoccured);
-	void ClearMD3CommandQueue();
 	void ProcessMD3Message(MD3Message_t&& CompleteMD3Message);
 
 	std::unique_ptr<ASIOScheduler> PollScheduler;
 	bool ProcessAnalogUnconditionalReturn( MD3BlockFormatted & Header, const MD3Message_t& CompleteMD3Message);
 	bool ProcessAnalogDeltaScanReturn( MD3BlockFormatted & Header, const MD3Message_t& CompleteMD3Message);
+	bool SetAnalogCounterAndSendEvent(const uint8_t ModuleAddress, const uint8_t idx, const uint16_t value, bool DeltaUpdate, bool OnlyUpdateTime);
 	bool ProcessAnalogNoChangeReturn(MD3BlockFormatted & Header, const MD3Message_t& CompleteMD3Message);
 
 	bool ProcessDigitalNoChangeReturn(MD3BlockFormatted & Header, const MD3Message_t & CompleteMD3Message);

--- a/Code/Ports/MD3Port/MD3OutstationPortHandlers.cpp
+++ b/Code/Ports/MD3Port/MD3OutstationPortHandlers.cpp
@@ -323,33 +323,33 @@ void MD3OutstationPort::ReadAnalogOrCounterRange(uint8_t ModuleAddress, uint8_t 
 	uint16_t wordres = 0;
 	bool hasbeenset;
 
-	// Is it a counter module? Fails if not at this address
+	// Can get up to 8 values from each module
+	uint8_t chancnt = Channels >= 8 ? 8 : Channels;
+	// Is it a counter or analog?
 	if (MyPointConf->PointTable.GetCounterValueUsingMD3Index(ModuleAddress, 0, wordres, hasbeenset))
 	{
-		// We have a counter module, can get up to 8 values from it
-		uint8_t chancnt = Channels >= 8 ? 8 : Channels;
 		GetAnalogModuleValues(CounterModule,chancnt, ModuleAddress, ResponseType, AnalogValues, AnalogDeltaValues);
-
-		if (Channels > 8)
-		{
-			// Now we have to get the remaining channels (up to 8) from the next module, if it exists.
-			// Check if it is a counter, otherwise assume analog. Will return correct error codes if not there
-			if (MyPointConf->PointTable.GetCounterValueUsingMD3Index(ModuleAddress+1, 0, wordres,hasbeenset))
-			{
-				GetAnalogModuleValues(CounterModule, Channels - 8, ModuleAddress + 1, ResponseType, AnalogValues, AnalogDeltaValues);
-			}
-			else
-			{
-				GetAnalogModuleValues(AnalogModule, Channels - 8, ModuleAddress + 1, ResponseType, AnalogValues, AnalogDeltaValues);
-			}
-		}
 	}
 	else
 	{
 		// It must be an analog module (if it does not exist, we return appropriate error codes anyway
 		// Yes proceed , up to 16 channels.
-		GetAnalogModuleValues(AnalogModule, Channels, ModuleAddress, ResponseType, AnalogValues, AnalogDeltaValues);
+		GetAnalogModuleValues(AnalogModule, chancnt, ModuleAddress, ResponseType, AnalogValues, AnalogDeltaValues);
 	}
+	if (Channels > 8)
+	{
+		// Now we have to get the remaining channels (up to 8) from the next module, if it exists.
+		// Check if it is a counter, otherwise assume analog. Will return correct error codes if not there
+		if (MyPointConf->PointTable.GetCounterValueUsingMD3Index(ModuleAddress+1, 0, wordres,hasbeenset))
+		{
+			GetAnalogModuleValues(CounterModule, Channels - 8, ModuleAddress + 1, ResponseType, AnalogValues, AnalogDeltaValues);
+		}
+		else
+		{
+			GetAnalogModuleValues(AnalogModule, Channels - 8, ModuleAddress + 1, ResponseType, AnalogValues, AnalogDeltaValues);
+		}
+	}
+	
 }
 void MD3OutstationPort::GetAnalogModuleValues(AnalogCounterModuleType IsCounterOrAnalog, uint8_t Channels, uint8_t ModuleAddress, MD3OutstationPort::AnalogChangeType & ResponseType, std::vector<uint16_t> & AnalogValues, std::vector<int> & AnalogDeltaValues)
 {

--- a/Code/Ports/MD3Port/MD3PointTableAccess.cpp
+++ b/Code/Ports/MD3Port/MD3PointTableAccess.cpp
@@ -43,7 +43,7 @@ void MD3PointTableAccess::Build(const bool isoutstation, const bool newdigitalco
 
 bool MD3PointTableAccess::AddCounterPointToPointTable(const size_t &index, const uint8_t &moduleaddress, const uint8_t &channel, const uint32_t &pollgroup)
 {
-	uint16_t md3index = ShiftLeft8Result16Bits(moduleaddress) | channel;
+	uint16_t md3index = CalcAnalogCounterMD3Index(moduleaddress, channel);
 	if (CounterMD3PointMap.find(md3index) != CounterMD3PointMap.end())
 	{
 		LOGERROR("Duplicate Counter MD3 Index " + std::to_string(moduleaddress) + " - " + std::to_string(channel));
@@ -63,7 +63,7 @@ bool MD3PointTableAccess::AddCounterPointToPointTable(const size_t &index, const
 }
 bool MD3PointTableAccess::AddAnalogPointToPointTable(const size_t &index, const uint8_t &moduleaddress, const uint8_t &channel, const uint32_t &pollgroup)
 {
-	uint16_t md3index = ShiftLeft8Result16Bits(moduleaddress) | channel;
+	uint16_t md3index = CalcAnalogCounterMD3Index(moduleaddress, channel);
 	if (AnalogMD3PointMap.find(md3index) != AnalogMD3PointMap.end())
 	{
 		LOGERROR("Duplicate Analog MD3 Index " + std::to_string(moduleaddress) + " - " + std::to_string(channel));
@@ -146,7 +146,7 @@ bool MD3PointTableAccess::AddBinaryControlPointToPointTable(const size_t &index,
 
 bool MD3PointTableAccess::GetCounterValueUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t &res, bool &hasbeenset)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = CounterMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != CounterMD3PointMap.end())
@@ -160,7 +160,7 @@ bool MD3PointTableAccess::GetCounterValueUsingMD3Index(const uint16_t module, co
 bool MD3PointTableAccess::GetCounterValueAndChangeUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t &res, int &delta, bool &hasbeenset)
 {
 	// Change being update the last read value
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = CounterMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != CounterMD3PointMap.end())
@@ -173,7 +173,7 @@ bool MD3PointTableAccess::GetCounterValueAndChangeUsingMD3Index(const uint16_t m
 }
 bool MD3PointTableAccess::SetCounterValueUsingMD3Index(const uint16_t module, const uint8_t channel, const uint16_t meas)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = CounterMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != CounterMD3PointMap.end())
@@ -185,7 +185,7 @@ bool MD3PointTableAccess::SetCounterValueUsingMD3Index(const uint16_t module, co
 }
 bool MD3PointTableAccess::GetCounterODCIndexUsingMD3Index(const uint16_t module, const uint8_t channel, size_t &res)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = CounterMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != CounterMD3PointMap.end())
@@ -218,7 +218,7 @@ bool MD3PointTableAccess::ResetCounterValueUsingODCIndex(const size_t index)
 
 bool MD3PointTableAccess::GetAnalogValueUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t &res, bool &hasbeenset)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = AnalogMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != AnalogMD3PointMap.end())
@@ -231,7 +231,7 @@ bool MD3PointTableAccess::GetAnalogValueUsingMD3Index(const uint16_t module, con
 }
 bool MD3PointTableAccess::GetAnalogValueAndChangeUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t &res, int &delta, bool &hasbeenset)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = AnalogMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != AnalogMD3PointMap.end())
@@ -244,7 +244,7 @@ bool MD3PointTableAccess::GetAnalogValueAndChangeUsingMD3Index(const uint16_t mo
 }
 bool MD3PointTableAccess::GetAnalogODCIndexUsingMD3Index(const uint16_t module, const uint8_t channel, size_t &res)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = AnalogMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != AnalogMD3PointMap.end())
@@ -256,7 +256,7 @@ bool MD3PointTableAccess::GetAnalogODCIndexUsingMD3Index(const uint16_t module, 
 }
 bool MD3PointTableAccess::SetAnalogValueUsingMD3Index(const uint16_t module, const uint8_t channel, const uint16_t meas)
 {
-	uint16_t Md3Index = ShiftLeft8Result16Bits(module) | channel;
+	uint16_t Md3Index = CalcAnalogCounterMD3Index(module, channel);
 
 	auto MD3PointMapIter = AnalogMD3PointMap.find(Md3Index);
 	if (MD3PointMapIter != AnalogMD3PointMap.end())
@@ -531,7 +531,7 @@ bool MD3PointTableAccess::GetAnalogControlMD3IndexUsingODCIndex(const size_t ind
 // Dumps the points out in a list, only used for UnitTests
 std::vector<MD3BinaryPoint> MD3PointTableAccess::DumpTimeTaggedPointList()
 {
-	std::vector<MD3BinaryPoint> PointList(50);
+	std::vector<MD3BinaryPoint> PointList(1);
 
 	while (!BinaryTimeTaggedEventQueue.empty())
 	{

--- a/Code/Ports/MD3Port/MD3PointTableAccess.h
+++ b/Code/Ports/MD3Port/MD3PointTableAccess.h
@@ -51,6 +51,19 @@ public:
 	bool AddBinaryPointToPointTable(const size_t & index, const uint8_t & moduleaddress, const uint8_t & channel, const BinaryPointType & pointtype, const uint32_t & pollgroup);
 	bool AddBinaryControlPointToPointTable(const size_t & index, const uint8_t & moduleaddress, const uint8_t & channel, const BinaryPointType & pointtype, const uint32_t & pollgroup);
 
+	uint16_t  CalcAnalogCounterMD3Index(const uint16_t module, const uint8_t channel)
+	{
+		if (channel > 7)	// Should only ever be 0 to 7, but if you do reference channels 8-15, then that is actually the next module up.
+		{
+			uint16_t modchannel = channel - 8;
+			uint8_t modmodule = module + 1;
+			return ShiftLeft8Result16Bits(modmodule) | modchannel;
+		}
+		else
+		{
+			return ShiftLeft8Result16Bits(module) | channel;
+		}
+	}
 	bool GetCounterValueUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t & res, bool &hasbeenset);
 	bool GetCounterValueAndChangeUsingMD3Index(const uint16_t module, const uint8_t channel, uint16_t & res, int & delta, bool &hasbeenset);
 	bool SetCounterValueUsingMD3Index(const uint16_t module, const uint8_t channel, const uint16_t meas);

--- a/Code/Ports/MD3Port/main.cpp
+++ b/Code/Ports/MD3Port/main.cpp
@@ -91,11 +91,13 @@ extern "C" int run_tests( int argc, char* argv[] )
 			new_argv = argv + 1;
 		}
 	}
-	CommandLineLoggingSetup(log_level);
+	if (log_level != spdlog::level::off)
+		CommandLineLoggingSetup(log_level);
 
 	return Catch::Session().run(new_argc, new_argv);
 	// And release here.
-	CommandLineLoggingCleanup();
+	if (log_level != spdlog::level::off)
+		CommandLineLoggingCleanup();
 	#else
 	std::cout << "MD3Port: Compiled for Visual Studio Testing only" << std::endl;
 	return 1;


### PR DESCRIPTION
Changes to MD3 to fix a bug on roll over of Module address/ Channel when channel > 8
Conitel fixes to support Fn9 Gp8 Status word and to support Status word correctly when a part of a group scan.
Slight changes to test logging when logging is off, so that console gives some feedback of what it is doing.