### PR TITLE
Fixed event time not being set in simulator for tap changers

### DIFF
--- a/Code/Ports/SimPort/SimPort.cpp
+++ b/Code/Ports/SimPort/SimPort.cpp
@@ -130,6 +130,7 @@ void SimPort::PublishBinaryEvents(const std::vector<std::size_t>& indexes, const
 	{
 		auto event = pSimConf->Event(odc::EventType::Binary, indexes[i]);
 		event->SetPayload<odc::EventType::Binary>(std::move(payload[i] - '0'));
+		event->SetTimestamp(msSinceEpoch());
 		PostPublishEvent(event);
 	}
 }
@@ -403,6 +404,7 @@ void SimPort::PortUp()
 	{
 		auto event = pSimConf->Event(odc::EventType::Binary, index);
 		bool val = event->GetPayload<odc::EventType::Binary>();
+		event->SetTimestamp(msSinceEpoch());
 		PostPublishEvent(event);
 
 		ptimer_t ptimer = pIOS->make_steady_timer();
@@ -882,6 +884,7 @@ CommandStatus SimPort::HandlePositionFeedbackForAnalog(const std::shared_ptr<Pos
 				{
 					payload += binary_position->tap_step;
 					event->SetPayload<odc::EventType::Analog>(std::move(payload));
+					event->SetTimestamp(msSinceEpoch());
 					PostPublishEvent(event);
 					message = "binary position event processing a success";
 					status = CommandStatus::SUCCESS;
@@ -898,6 +901,7 @@ CommandStatus SimPort::HandlePositionFeedbackForAnalog(const std::shared_ptr<Pos
 				{
 					payload -= binary_position->tap_step;
 					event->SetPayload<odc::EventType::Analog>(std::move(payload));
+					event->SetTimestamp(msSinceEpoch());
 					PostPublishEvent(event);
 					message = "binary position event processing a success";
 					status = CommandStatus::SUCCESS;


### PR DESCRIPTION
(cherry picked from commit 39d36c91155c30b27e88cac6fe0cbe1af40f5105)